### PR TITLE
Kep 2349 impl

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -279,6 +279,65 @@ type MultiKueue struct {
 	// - If not specified, the workload will be handled by the default ("kueue.x-k8s.io/multikueue-dispatcher-all-at-once") dispatcher.
 	// +optional
 	DispatcherName *string `json:"dispatcherName,omitempty"`
+
+	// ExternalFrameworks defines a list of external frameworks that should be supported
+	// by the generic MultiKueue adapter. Each entry defines how to handle a specific
+	// GroupVersionKind (GVK) for MultiKueue operations.
+	// +optional
+	ExternalFrameworks []ExternalFramework `json:"externalFrameworks,omitempty"`
+}
+
+// ExternalFramework defines how to handle a specific GroupVersionKind (GVK) for MultiKueue operations.
+type ExternalFramework struct {
+	// Group is the API group of the custom resource.
+	// +kubebuilder:validation:Required
+	Group string `json:"group"`
+
+	// Version is the API version of the custom resource.
+	// +kubebuilder:validation:Required
+	Version string `json:"version"`
+
+	// Kind is the kind of the custom resource.
+	// +kubebuilder:validation:Required
+	Kind string `json:"kind"`
+
+	// ManagedBy defines the JSONPath expression to check if the object is managed by Kueue.
+	// This field is used to determine if a job object is managed by Kueue and can be delegated.
+	// Defaults to ".spec.managedBy".
+	// +optional
+	ManagedBy string `json:"managedBy,omitempty"`
+
+	// CreationPatches defines a list of JSON patches to apply when creating the object in the worker cluster.
+	// These patches are applied to the local object before creating it in the remote cluster.
+	// +optional
+	CreationPatches []JsonPatch `json:"creationPatches,omitempty"`
+
+	// SyncPatches defines a list of JSON patches to apply when synchronizing status from the worker cluster.
+	// These patches are used to copy status information from the remote object to the local object.
+	// +optional
+	SyncPatches []JsonPatch `json:"syncPatches,omitempty"`
+}
+
+// JsonPatch represents a JSON patch operation as defined in RFC 6902.
+type JsonPatch struct {
+	// Op is the operation to be performed.
+	// +kubebuilder:validation:Enum=add;remove;replace;move;copy;test
+	// +kubebuilder:validation:Required
+	Op string `json:"op"`
+
+	// Path is the JSON pointer path to the target location.
+	// +kubebuilder:validation:Required
+	Path string `json:"path"`
+
+	// Value is the value to be used in the operation.
+	// This field is required for "add" and "replace" operations.
+	// +optional
+	Value interface{} `json:"value,omitempty"`
+
+	// From is the JSON pointer path to the source location.
+	// This field is required for "move" and "copy" operations.
+	// +optional
+	From string `json:"from,omitempty"`
 }
 
 const (

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -284,60 +284,16 @@ type MultiKueue struct {
 	// by the generic MultiKueue adapter. Each entry defines how to handle a specific
 	// GroupVersionKind (GVK) for MultiKueue operations.
 	// +optional
-	ExternalFrameworks []ExternalFramework `json:"externalFrameworks,omitempty"`
+	ExternalFrameworks []MultiKueueExternalFramework `json:"externalFrameworks,omitempty"`
 }
 
-// ExternalFramework defines how to handle a specific GroupVersionKind (GVK) for MultiKueue operations.
-type ExternalFramework struct {
-	// Group is the API group of the custom resource.
+// MultiKueueExternalFramework defines a framework that is not built-in.
+type MultiKueueExternalFramework struct {
+	// Name is the GVK of the resource that are
+	// managed by external controllers
+	// the expected format is `Kind.version.group.com`.
 	// +kubebuilder:validation:Required
-	Group string `json:"group"`
-
-	// Version is the API version of the custom resource.
-	// +kubebuilder:validation:Required
-	Version string `json:"version"`
-
-	// Kind is the kind of the custom resource.
-	// +kubebuilder:validation:Required
-	Kind string `json:"kind"`
-
-	// ManagedBy defines the JSONPath expression to check if the object is managed by Kueue.
-	// This field is used to determine if a job object is managed by Kueue and can be delegated.
-	// Defaults to ".spec.managedBy".
-	// +optional
-	ManagedBy string `json:"managedBy,omitempty"`
-
-	// CreationPatches defines a list of JSON patches to apply when creating the object in the worker cluster.
-	// These patches are applied to the local object before creating it in the remote cluster.
-	// +optional
-	CreationPatches []JsonPatch `json:"creationPatches,omitempty"`
-
-	// SyncPatches defines a list of JSON patches to apply when synchronizing status from the worker cluster.
-	// These patches are used to copy status information from the remote object to the local object.
-	// +optional
-	SyncPatches []JsonPatch `json:"syncPatches,omitempty"`
-}
-
-// JsonPatch represents a JSON patch operation as defined in RFC 6902.
-type JsonPatch struct {
-	// Op is the operation to be performed.
-	// +kubebuilder:validation:Enum=add;remove;replace;move;copy;test
-	// +kubebuilder:validation:Required
-	Op string `json:"op"`
-
-	// Path is the JSON pointer path to the target location.
-	// +kubebuilder:validation:Required
-	Path string `json:"path"`
-
-	// Value is the value to be used in the operation.
-	// This field is required for "add" and "replace" operations.
-	// +optional
-	Value interface{} `json:"value,omitempty"`
-
-	// From is the JSON pointer path to the source location.
-	// This field is required for "move" and "copy" operations.
-	// +optional
-	From string `json:"from,omitempty"`
+	Name string `json:"name"`
 }
 
 const (

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"flag"
 	"fmt"
 	"net/http"
@@ -60,6 +61,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/generic"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/debugger"
@@ -341,6 +343,34 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.C
 		if err != nil {
 			return fmt.Errorf("could not get the enabled multikueue adapters: %w", err)
 		}
+
+		// Add generic adapters if the feature gate is enabled
+		setupLog.Info("Checking MultiKueue config",
+			"featureGateEnabled", features.Enabled(features.MultiKueueAdaptersForCustomJobs),
+			"isNil", cfg.MultiKueue == nil)
+		if cfg.MultiKueue != nil {
+			setupLog.Info("MultiKueue config details", "externalFrameworksCount", len(cfg.MultiKueue.ExternalFrameworks))
+		}
+		if features.Enabled(features.MultiKueueAdaptersForCustomJobs) && cfg.MultiKueue != nil && len(cfg.MultiKueue.ExternalFrameworks) > 0 {
+			genericConfigManager := generic.NewConfigManager()
+			if err := genericConfigManager.LoadConfigurations(cfg.MultiKueue.ExternalFrameworks); err != nil {
+				setupLog.Error(err, "Could not load generic adapter configurations")
+				os.Exit(1)
+			}
+			setupLog.Info("inside generic creation")
+
+			// Add generic adapters to the adapters map
+			for _, adapter := range genericConfigManager.GetAllAdapters() {
+				gvkStr := adapter.GVK().String()
+				if _, exists := adapters[gvkStr]; exists {
+					setupLog.Error(fmt.Errorf("duplicate adapter for GVK %s", gvkStr), "Generic adapter conflicts with built-in adapter")
+					os.Exit(1)
+				}
+				setupLog.Info("Creating generic MultiKueue adapter", "gvk", gvkStr)
+				adapters[gvkStr] = adapter
+			}
+		}
+
 		if err := multikueue.SetupControllers(mgr, *cfg.Namespace,
 			multikueue.WithGCInterval(cfg.MultiKueue.GCInterval.Duration),
 			multikueue.WithOrigin(ptr.Deref(cfg.MultiKueue.Origin, configapi.DefaultMultiKueueOrigin)),

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"flag"
 	"fmt"
 	"net/http"
@@ -357,7 +356,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *schdcache.C
 				setupLog.Error(err, "Could not load generic adapter configurations")
 				os.Exit(1)
 			}
-			setupLog.Info("inside generic creation")
+			setupLog.Info("Creating generic adapters")
 
 			// Add generic adapters to the adapters map
 			for _, adapter := range genericConfigManager.GetAllAdapters() {

--- a/docs/external-frameworks-multikueue.md
+++ b/docs/external-frameworks-multikueue.md
@@ -1,0 +1,255 @@
+# MultiKueue External Frameworks Support
+
+This document explains how to use MultiKueue with external frameworks that are not natively supported by Kueue.
+
+## Overview
+
+MultiKueue External Frameworks Support allows you to configure MultiKueue to work with any Custom Resource (CR) that follows the standard Kubernetes patterns. This feature is particularly useful for:
+
+- Tekton PipelineRun
+- Argo Workflows
+- Custom job types
+- Any CR that has a `managedBy` field or similar mechanism
+
+## Feature Gate
+
+This feature is controlled by the `MultiKueueAdaptersForCustomJobs` feature gate:
+
+- **Alpha (v0.14)**: Disabled by default
+- **Beta (v0.15)**: Enabled by default
+- **GA**: Feature gate removed
+
+To enable the feature:
+
+```bash
+# Enable the feature gate
+kubectl patch deployment kueue-controller-manager -n kueue-system \
+  --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--feature-gates=MultiKueueAdaptersForCustomJobs=true"}]'
+```
+
+## Configuration
+
+External frameworks are configured in the Kueue configuration under the `multikueue.externalFrameworks` section.
+
+### Basic Configuration
+
+The minimal configuration requires only the Group, Version, and Kind:
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    externalFrameworks:
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+```
+
+This configuration will use the following defaults:
+- `managedBy`: `.spec.managedBy`
+- `creationPatches`: Replace `/spec/managedBy` with `null`
+- `syncPatches`: Copy entire `/status` from remote to local
+
+### Advanced Configuration
+
+You can customize the behavior with additional fields:
+
+```yaml
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    externalFrameworks:
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+        managedBy: ".spec.managedBy"
+        creationPatches:
+          - op: replace
+            path: /spec/managedBy
+            value: null
+          - op: replace
+            path: /spec/pipelineRef
+            value:
+              name: "remote-pipeline"
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+          - op: replace
+            path: /status/conditions
+            from: /status/conditions
+```
+
+## Configuration Fields
+
+### ExternalFramework
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `group` | string | Yes | API group of the custom resource |
+| `version` | string | Yes | API version of the custom resource |
+| `kind` | string | Yes | Kind of the custom resource |
+| `managedBy` | string | No | JSONPath to the managedBy field (default: `.spec.managedBy`) |
+| `creationPatches` | []JsonPatch | No | Patches to apply when creating in worker cluster |
+| `syncPatches` | []JsonPatch | No | Patches to apply when syncing status |
+
+### JsonPatch
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `op` | string | Yes | Operation: `add`, `remove`, `replace`, `move`, `copy`, `test` |
+| `path` | string | Yes | JSON pointer path to target location |
+| `value` | interface{} | No | Value for `add` and `replace` operations |
+| `from` | string | No | Source path for `move` and `copy` operations |
+
+## Usage Examples
+
+### Tekton PipelineRun
+
+```yaml
+# Configuration
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    externalFrameworks:
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+
+---
+# PipelineRun with MultiKueue
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: example-pipeline
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  managedBy: "kueue.x-k8s.io/multikueue"
+  pipelineRef:
+    name: example-pipeline
+```
+
+### Custom Job with Different managedBy Path
+
+```yaml
+# Configuration
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    externalFrameworks:
+      - group: "custom.example.com"
+        version: "v1alpha1"
+        kind: "CustomJob"
+        managedBy: ".metadata.labels.managedBy"
+        creationPatches:
+          - op: replace
+            path: /metadata/labels/managedBy
+            value: null
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+
+---
+# Custom Job
+apiVersion: custom.example.com/v1alpha1
+kind: CustomJob
+metadata:
+  name: example-job
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+    managedBy: "kueue.x-k8s.io/multikueue"
+spec:
+  # ... job specification
+```
+
+## How It Works
+
+1. **Detection**: When a workload is created for a configured GVK, the generic adapter checks if the object is managed by Kueue using the `managedBy` field.
+
+2. **Creation**: When the workload is admitted, the generic adapter:
+   - Creates a copy of the object in the worker cluster
+   - Applies the `creationPatches` to modify the object for the worker cluster
+   - Adds MultiKueue labels for tracking
+
+3. **Status Sync**: The generic adapter periodically:
+   - Fetches the status from the worker cluster
+   - Applies the `syncPatches` to update the local object's status
+
+4. **Cleanup**: When the workload is deleted, the generic adapter removes the object from the worker cluster.
+
+## Limitations
+
+- The generic adapter only supports simple JSON patch operations
+- Complex transformations require custom patches
+- The `managedBy` field must be accessible via JSONPath
+- Status synchronization is limited to the configured patches
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Object not managed by Kueue**
+   - Ensure the `managedBy` field is set to `"kueue.x-k8s.io/multikueue"`
+   - Check that the `managedBy` path in configuration is correct
+
+2. **Patch application failures**
+   - Verify JSON patch syntax
+   - Ensure paths exist in the object structure
+   - Check that patch operations are valid for the target paths
+
+3. **Status not syncing**
+   - Verify `syncPatches` configuration
+   - Check that remote object has the expected status structure
+   - Ensure worker cluster connectivity
+
+### Debugging
+
+Enable debug logging to see detailed information about adapter operations:
+
+```bash
+kubectl logs -n kueue-system deployment/kueue-controller-manager -f --v=4
+```
+
+Look for log messages containing:
+- `generic adapter`
+- `external framework`
+- `patch application`
+- `status sync`
+
+## Migration from Built-in Adapters
+
+If you're currently using a built-in adapter and want to switch to the generic adapter:
+
+1. Add the external framework configuration
+2. Ensure the same GVK is not configured in both places
+3. Test with a small subset of workloads
+4. Monitor for any differences in behavior
+5. Gradually migrate all workloads
+
+## Best Practices
+
+1. **Start Simple**: Begin with minimal configuration and add complexity as needed
+2. **Test Thoroughly**: Test patches with sample objects before production use
+3. **Monitor Performance**: Generic adapters may have different performance characteristics
+4. **Document Configuration**: Keep detailed documentation of your external framework configurations
+5. **Version Control**: Store configurations in version control for reproducibility

--- a/docs/external-frameworks-multikueue.md
+++ b/docs/external-frameworks-multikueue.md
@@ -33,7 +33,7 @@ External frameworks are configured in the Kueue configuration under the `multiku
 
 ### Basic Configuration
 
-The minimal configuration requires only the Group, Version, and Kind:
+The configuration requires only the GVK in the format `Kind.version.group.com`:
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta1
@@ -44,71 +44,21 @@ metadata:
 data:
   multikueue:
     externalFrameworks:
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
+      - name: "PipelineRun.v1.tekton.dev"
 ```
 
 This configuration will use the following defaults:
-- `managedBy`: `.spec.managedBy`
-- `creationPatches`: Replace `/spec/managedBy` with `null`
-- `syncPatches`: Copy entire `/status` from remote to local
-
-### Advanced Configuration
-
-You can customize the behavior with additional fields:
-
-```yaml
-apiVersion: config.kueue.x-k8s.io/v1beta1
-kind: Configuration
-metadata:
-  name: kueue-manager-config
-  namespace: kueue-system
-data:
-  multikueue:
-    externalFrameworks:
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
-        managedBy: ".spec.managedBy"
-        creationPatches:
-          - op: replace
-            path: /spec/managedBy
-            value: null
-          - op: replace
-            path: /spec/pipelineRef
-            value:
-              name: "remote-pipeline"
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
-          - op: replace
-            path: /status/conditions
-            from: /status/conditions
-```
+- `managedBy`: `.spec.managedBy` (hardcoded)
+- Creation: Remove `.spec.managedBy` field
+- Status sync: Copy entire `/status` from remote to local
 
 ## Configuration Fields
 
-### ExternalFramework
+### MultiKueueExternalFramework
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `group` | string | Yes | API group of the custom resource |
-| `version` | string | Yes | API version of the custom resource |
-| `kind` | string | Yes | Kind of the custom resource |
-| `managedBy` | string | No | JSONPath to the managedBy field (default: `.spec.managedBy`) |
-| `creationPatches` | []JsonPatch | No | Patches to apply when creating in worker cluster |
-| `syncPatches` | []JsonPatch | No | Patches to apply when syncing status |
-
-### JsonPatch
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `op` | string | Yes | Operation: `add`, `remove`, `replace`, `move`, `copy`, `test` |
-| `path` | string | Yes | JSON pointer path to target location |
-| `value` | interface{} | No | Value for `add` and `replace` operations |
-| `from` | string | No | Source path for `move` and `copy` operations |
+| `name` | string | Yes | GVK in format `Kind.version.group.com` |
 
 ## Usage Examples
 
@@ -124,132 +74,9 @@ metadata:
 data:
   multikueue:
     externalFrameworks:
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
-
----
-# PipelineRun with MultiKueue
-apiVersion: tekton.dev/v1
-kind: PipelineRun
-metadata:
-  name: example-pipeline
-  namespace: default
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-spec:
-  managedBy: "kueue.x-k8s.io/multikueue"
-  pipelineRef:
-    name: example-pipeline
+      - name: "PipelineRun.v1.tekton.dev"
 ```
 
 ### Custom Job with Different managedBy Path
 
-```yaml
-# Configuration
-apiVersion: config.kueue.x-k8s.io/v1beta1
-kind: Configuration
-metadata:
-  name: kueue-manager-config
-  namespace: kueue-system
-data:
-  multikueue:
-    externalFrameworks:
-      - group: "custom.example.com"
-        version: "v1alpha1"
-        kind: "CustomJob"
-        managedBy: ".metadata.labels.managedBy"
-        creationPatches:
-          - op: replace
-            path: /metadata/labels/managedBy
-            value: null
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
-
----
-# Custom Job
-apiVersion: custom.example.com/v1alpha1
-kind: CustomJob
-metadata:
-  name: example-job
-  namespace: default
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-    managedBy: "kueue.x-k8s.io/multikueue"
-spec:
-  # ... job specification
 ```
-
-## How It Works
-
-1. **Detection**: When a workload is created for a configured GVK, the generic adapter checks if the object is managed by Kueue using the `managedBy` field.
-
-2. **Creation**: When the workload is admitted, the generic adapter:
-   - Creates a copy of the object in the worker cluster
-   - Applies the `creationPatches` to modify the object for the worker cluster
-   - Adds MultiKueue labels for tracking
-
-3. **Status Sync**: The generic adapter periodically:
-   - Fetches the status from the worker cluster
-   - Applies the `syncPatches` to update the local object's status
-
-4. **Cleanup**: When the workload is deleted, the generic adapter removes the object from the worker cluster.
-
-## Limitations
-
-- The generic adapter only supports simple JSON patch operations
-- Complex transformations require custom patches
-- The `managedBy` field must be accessible via JSONPath
-- Status synchronization is limited to the configured patches
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Object not managed by Kueue**
-   - Ensure the `managedBy` field is set to `"kueue.x-k8s.io/multikueue"`
-   - Check that the `managedBy` path in configuration is correct
-
-2. **Patch application failures**
-   - Verify JSON patch syntax
-   - Ensure paths exist in the object structure
-   - Check that patch operations are valid for the target paths
-
-3. **Status not syncing**
-   - Verify `syncPatches` configuration
-   - Check that remote object has the expected status structure
-   - Ensure worker cluster connectivity
-
-### Debugging
-
-Enable debug logging to see detailed information about adapter operations:
-
-```bash
-kubectl logs -n kueue-system deployment/kueue-controller-manager -f --v=4
-```
-
-Look for log messages containing:
-- `generic adapter`
-- `external framework`
-- `patch application`
-- `status sync`
-
-## Migration from Built-in Adapters
-
-If you're currently using a built-in adapter and want to switch to the generic adapter:
-
-1. Add the external framework configuration
-2. Ensure the same GVK is not configured in both places
-3. Test with a small subset of workloads
-4. Monitor for any differences in behavior
-5. Gradually migrate all workloads
-
-## Best Practices
-
-1. **Start Simple**: Begin with minimal configuration and add complexity as needed
-2. **Test Thoroughly**: Test patches with sample objects before production use
-3. **Monitor Performance**: Generic adapters may have different performance characteristics
-4. **Document Configuration**: Keep detailed documentation of your external framework configurations
-5. **Version Control**: Store configurations in version control for reproducibility

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,6 +38,8 @@ func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.Configuration)
 		return err
 	}
 
+	ctrl.Log.WithName("config").Info("Raw configuration file content", "content", string(content))
+
 	codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
 
 	// Regardless of if the bytes are of any external version,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,8 +38,6 @@ func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.Configuration)
 		return err
 	}
 
-	ctrl.Log.WithName("config").Info("Raw configuration file content", "content", string(content))
-
 	codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
 
 	// Regardless of if the bytes are of any external version,

--- a/pkg/controller/jobs/generic/config.go
+++ b/pkg/controller/jobs/generic/config.go
@@ -1,0 +1,204 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+)
+
+// ConfigManager manages external framework configurations for generic adapters
+type ConfigManager struct {
+	configs map[string]configapi.ExternalFramework
+}
+
+// NewConfigManager creates a new configuration manager
+func NewConfigManager() *ConfigManager {
+	return &ConfigManager{
+		configs: make(map[string]configapi.ExternalFramework),
+	}
+}
+
+// LoadConfigurations loads and validates external framework configurations
+func (cm *ConfigManager) LoadConfigurations(configs []configapi.ExternalFramework) error {
+	cm.configs = make(map[string]configapi.ExternalFramework)
+
+	for _, config := range configs {
+		if err := cm.validateConfig(config); err != nil {
+			klog.Errorf("Invalid external framework configuration: %v", err)
+			continue // Skip invalid configurations but continue loading others
+		}
+
+		// Apply default values
+		config = cm.applyDefaults(config)
+
+		// Store the configuration
+		gvk := schema.GroupVersionKind{
+			Group:   config.Group,
+			Version: config.Version,
+			Kind:    config.Kind,
+		}
+		cm.configs[gvk.String()] = config
+	}
+
+	return nil
+}
+
+// GetAdapter returns a generic adapter for the given GVK if configured
+func (cm *ConfigManager) GetAdapter(gvk schema.GroupVersionKind) *genericAdapter {
+	config, exists := cm.configs[gvk.String()]
+	if !exists {
+		return nil
+	}
+
+	return &genericAdapter{
+		config: config,
+		gvk:    gvk,
+	}
+}
+
+// GetAllAdapters returns all configured generic adapters
+func (cm *ConfigManager) GetAllAdapters() []*genericAdapter {
+	adapters := make([]*genericAdapter, 0, len(cm.configs))
+	for _, config := range cm.configs {
+		gvk := schema.GroupVersionKind{
+			Group:   config.Group,
+			Version: config.Version,
+			Kind:    config.Kind,
+		}
+		adapters = append(adapters, &genericAdapter{
+			config: config,
+			gvk:    gvk,
+		})
+	}
+	return adapters
+}
+
+// validateConfig validates an external framework configuration
+func (cm *ConfigManager) validateConfig(config configapi.ExternalFramework) error {
+	if config.Group == "" {
+		return fmt.Errorf("group is required")
+	}
+	if config.Version == "" {
+		return fmt.Errorf("version is required")
+	}
+	if config.Kind == "" {
+		return fmt.Errorf("kind is required")
+	}
+
+	// Validate managedBy path if provided
+	if config.ManagedBy != "" {
+		if !strings.HasPrefix(config.ManagedBy, ".") {
+			return fmt.Errorf("managedBy path must start with '.'")
+		}
+	}
+
+	// Validate JSON patches
+	if err := cm.validateJsonPatches(config.CreationPatches); err != nil {
+		return fmt.Errorf("invalid creation patches: %w", err)
+	}
+	if err := cm.validateJsonPatches(config.SyncPatches); err != nil {
+		return fmt.Errorf("invalid sync patches: %w", err)
+	}
+
+	return nil
+}
+
+// validateJsonPatches validates a list of JSON patches
+func (cm *ConfigManager) validateJsonPatches(patches []configapi.JsonPatch) error {
+	for i, patch := range patches {
+		if err := cm.validateJsonPatch(patch); err != nil {
+			return fmt.Errorf("patch[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// validateJsonPatch validates a single JSON patch
+func (cm *ConfigManager) validateJsonPatch(patch configapi.JsonPatch) error {
+	// Validate operation
+	validOps := map[string]bool{
+		"add":     true,
+		"remove":  true,
+		"replace": true,
+		"move":    true,
+		"copy":    true,
+		"test":    true,
+	}
+	if !validOps[patch.Op] {
+		return fmt.Errorf("invalid operation: %s", patch.Op)
+	}
+
+	// Validate path
+	if patch.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+	if !strings.HasPrefix(patch.Path, "/") {
+		return fmt.Errorf("path must start with '/'")
+	}
+
+	// Validate value for add/replace operations
+	if (patch.Op == "add" || patch.Op == "replace") && patch.Value == nil {
+		return fmt.Errorf("value is required for %s operation", patch.Op)
+	}
+
+	// Validate from field for move/copy operations
+	if (patch.Op == "move" || patch.Op == "copy") && patch.From == "" {
+		return fmt.Errorf("from field is required for %s operation", patch.Op)
+	}
+
+	return nil
+}
+
+// applyDefaults applies default values to a configuration
+func (cm *ConfigManager) applyDefaults(config configapi.ExternalFramework) configapi.ExternalFramework {
+	// Set default managedBy path if not provided
+	if config.ManagedBy == "" {
+		config.ManagedBy = ".spec.managedBy"
+	}
+
+	// Set default creation patches if not provided
+	if len(config.CreationPatches) == 0 {
+		// Default to removing the managedBy field.
+		// The path is transformed from ".spec.managedBy" to "/spec/managedBy".
+		path := "/" + strings.ReplaceAll(strings.TrimPrefix(config.ManagedBy, "."), ".", "/")
+		config.CreationPatches = []configapi.JsonPatch{
+			{
+				Op:   "remove",
+				Path: path,
+			},
+		}
+	}
+
+	// Set default sync patches if not provided
+	if len(config.SyncPatches) == 0 {
+		config.SyncPatches = []configapi.JsonPatch{
+			{
+				Op:   "replace",
+				Path: "/status",
+				From: "/status",
+			},
+		}
+	}
+
+	return config
+}

--- a/pkg/controller/jobs/generic/config.go
+++ b/pkg/controller/jobs/generic/config.go
@@ -18,7 +18,6 @@ package generic
 
 import (
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -28,51 +27,56 @@ import (
 
 // ConfigManager manages external framework configurations for generic adapters
 type ConfigManager struct {
-	configs map[string]configapi.ExternalFramework
+	configs map[string]configapi.MultiKueueExternalFramework
 }
 
 // NewConfigManager creates a new configuration manager
 func NewConfigManager() *ConfigManager {
 	return &ConfigManager{
-		configs: make(map[string]configapi.ExternalFramework),
+		configs: make(map[string]configapi.MultiKueueExternalFramework),
 	}
 }
 
 // LoadConfigurations loads and validates external framework configurations
-func (cm *ConfigManager) LoadConfigurations(configs []configapi.ExternalFramework) error {
-	cm.configs = make(map[string]configapi.ExternalFramework)
+func (cm *ConfigManager) LoadConfigurations(configs []configapi.MultiKueueExternalFramework) error {
+	cm.configs = make(map[string]configapi.MultiKueueExternalFramework)
+	var errors []error
 
 	for _, config := range configs {
 		if err := cm.validateConfig(config); err != nil {
 			klog.Errorf("Invalid external framework configuration: %v", err)
+			errors = append(errors, fmt.Errorf("config %s: %w", config.Name, err))
 			continue // Skip invalid configurations but continue loading others
 		}
 
-		// Apply default values
-		config = cm.applyDefaults(config)
+		// Parse the GVK from the name field using schema.ParseKindArg
+		gvk, _ := schema.ParseKindArg(config.Name)
+		if gvk == nil {
+			err := fmt.Errorf("invalid GVK format in configuration: %s", config.Name)
+			klog.Error(err)
+			errors = append(errors, err)
+			continue
+		}
 
 		// Store the configuration
-		gvk := schema.GroupVersionKind{
-			Group:   config.Group,
-			Version: config.Version,
-			Kind:    config.Kind,
-		}
 		cm.configs[gvk.String()] = config
 	}
 
+	if len(errors) > 0 {
+		return fmt.Errorf("encountered %d configuration errors (see logs for details)", len(errors))
+	}
 	return nil
 }
 
 // GetAdapter returns a generic adapter for the given GVK if configured
 func (cm *ConfigManager) GetAdapter(gvk schema.GroupVersionKind) *genericAdapter {
-	config, exists := cm.configs[gvk.String()]
+	_, exists := cm.configs[gvk.String()]
 	if !exists {
 		return nil
 	}
 
 	return &genericAdapter{
-		config: config,
-		gvk:    gvk,
+		gvk: gvk,
 	}
 }
 
@@ -80,125 +84,30 @@ func (cm *ConfigManager) GetAdapter(gvk schema.GroupVersionKind) *genericAdapter
 func (cm *ConfigManager) GetAllAdapters() []*genericAdapter {
 	adapters := make([]*genericAdapter, 0, len(cm.configs))
 	for _, config := range cm.configs {
-		gvk := schema.GroupVersionKind{
-			Group:   config.Group,
-			Version: config.Version,
-			Kind:    config.Kind,
+		// Parse the GVK string back to schema.GroupVersionKind
+		gvk, _ := schema.ParseKindArg(config.Name)
+		if gvk == nil {
+			klog.Errorf("Failed to parse GVK string %s", config.Name)
+			continue
 		}
 		adapters = append(adapters, &genericAdapter{
-			config: config,
-			gvk:    gvk,
+			gvk: *gvk,
 		})
 	}
 	return adapters
 }
 
 // validateConfig validates an external framework configuration
-func (cm *ConfigManager) validateConfig(config configapi.ExternalFramework) error {
-	if config.Group == "" {
-		return fmt.Errorf("group is required")
-	}
-	if config.Version == "" {
-		return fmt.Errorf("version is required")
-	}
-	if config.Kind == "" {
-		return fmt.Errorf("kind is required")
+func (cm *ConfigManager) validateConfig(config configapi.MultiKueueExternalFramework) error {
+	if config.Name == "" {
+		return fmt.Errorf("name is required")
 	}
 
-	// Validate managedBy path if provided
-	if config.ManagedBy != "" {
-		if !strings.HasPrefix(config.ManagedBy, ".") {
-			return fmt.Errorf("managedBy path must start with '.'")
-		}
-	}
-
-	// Validate JSON patches
-	if err := cm.validateJsonPatches(config.CreationPatches); err != nil {
-		return fmt.Errorf("invalid creation patches: %w", err)
-	}
-	if err := cm.validateJsonPatches(config.SyncPatches); err != nil {
-		return fmt.Errorf("invalid sync patches: %w", err)
+	// Validate the GVK format using schema.ParseKindArg
+	gvk, _ := schema.ParseKindArg(config.Name)
+	if gvk == nil {
+		return fmt.Errorf("invalid GVK format '%s'", config.Name)
 	}
 
 	return nil
-}
-
-// validateJsonPatches validates a list of JSON patches
-func (cm *ConfigManager) validateJsonPatches(patches []configapi.JsonPatch) error {
-	for i, patch := range patches {
-		if err := cm.validateJsonPatch(patch); err != nil {
-			return fmt.Errorf("patch[%d]: %w", i, err)
-		}
-	}
-	return nil
-}
-
-// validateJsonPatch validates a single JSON patch
-func (cm *ConfigManager) validateJsonPatch(patch configapi.JsonPatch) error {
-	// Validate operation
-	validOps := map[string]bool{
-		"add":     true,
-		"remove":  true,
-		"replace": true,
-		"move":    true,
-		"copy":    true,
-		"test":    true,
-	}
-	if !validOps[patch.Op] {
-		return fmt.Errorf("invalid operation: %s", patch.Op)
-	}
-
-	// Validate path
-	if patch.Path == "" {
-		return fmt.Errorf("path is required")
-	}
-	if !strings.HasPrefix(patch.Path, "/") {
-		return fmt.Errorf("path must start with '/'")
-	}
-
-	// Validate value for add/replace operations
-	if (patch.Op == "add" || patch.Op == "replace") && patch.Value == nil {
-		return fmt.Errorf("value is required for %s operation", patch.Op)
-	}
-
-	// Validate from field for move/copy operations
-	if (patch.Op == "move" || patch.Op == "copy") && patch.From == "" {
-		return fmt.Errorf("from field is required for %s operation", patch.Op)
-	}
-
-	return nil
-}
-
-// applyDefaults applies default values to a configuration
-func (cm *ConfigManager) applyDefaults(config configapi.ExternalFramework) configapi.ExternalFramework {
-	// Set default managedBy path if not provided
-	if config.ManagedBy == "" {
-		config.ManagedBy = ".spec.managedBy"
-	}
-
-	// Set default creation patches if not provided
-	if len(config.CreationPatches) == 0 {
-		// Default to removing the managedBy field.
-		// The path is transformed from ".spec.managedBy" to "/spec/managedBy".
-		path := "/" + strings.ReplaceAll(strings.TrimPrefix(config.ManagedBy, "."), ".", "/")
-		config.CreationPatches = []configapi.JsonPatch{
-			{
-				Op:   "remove",
-				Path: path,
-			},
-		}
-	}
-
-	// Set default sync patches if not provided
-	if len(config.SyncPatches) == 0 {
-		config.SyncPatches = []configapi.JsonPatch{
-			{
-				Op:   "replace",
-				Path: "/status",
-				From: "/status",
-			},
-		}
-	}
-
-	return config
 }

--- a/pkg/controller/jobs/generic/config_test.go
+++ b/pkg/controller/jobs/generic/config_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+)
+
+func TestConfigManager_LoadConfigurations(t *testing.T) {
+	cm := NewConfigManager()
+
+	tests := []struct {
+		name    string
+		configs []configapi.MultiKueueExternalFramework
+		wantErr bool
+	}{
+		{
+			name: "valid configurations",
+			configs: []configapi.MultiKueueExternalFramework{
+				{Name: "PipelineRun.v1.tekton.dev"},
+				{Name: "CustomJob.v1alpha1.custom.example.com"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid GVK format",
+			configs: []configapi.MultiKueueExternalFramework{
+				{Name: "invalid-format"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty name",
+			configs: []configapi.MultiKueueExternalFramework{
+				{Name: ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mixed valid and invalid",
+			configs: []configapi.MultiKueueExternalFramework{
+				{Name: "PipelineRun.v1.tekton.dev"},
+				{Name: "invalid-format"},
+				{Name: "Workflow.v1alpha1.argoproj.io"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cm.LoadConfigurations(tt.configs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConfigManager.LoadConfigurations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfigManager_GetAdapter(t *testing.T) {
+	cm := NewConfigManager()
+	
+	// Load a valid configuration
+	configs := []configapi.MultiKueueExternalFramework{
+		{Name: "PipelineRun.v1.tekton.dev"},
+	}
+	err := cm.LoadConfigurations(configs)
+	if err != nil {
+		t.Fatalf("Failed to load configurations: %v", err)
+	}
+
+	// Test getting adapter for configured GVK
+	gvk := schema.GroupVersionKind{
+		Group:   "tekton.dev",
+		Version: "v1",
+		Kind:    "PipelineRun",
+	}
+	
+	adapter := cm.GetAdapter(gvk)
+	if adapter == nil {
+		t.Error("Expected adapter to be returned for configured GVK")
+	}
+	if adapter.GVK() != gvk {
+		t.Errorf("Expected GVK %v, got %v", gvk, adapter.GVK())
+	}
+
+	// Test getting adapter for unconfigured GVK
+	unconfiguredGVK := schema.GroupVersionKind{
+		Group:   "example.com",
+		Version: "v1",
+		Kind:    "Example",
+	}
+	
+	unconfiguredAdapter := cm.GetAdapter(unconfiguredGVK)
+	if unconfiguredAdapter != nil {
+		t.Error("Expected nil adapter for unconfigured GVK")
+	}
+}
+
+func TestConfigManager_GetAllAdapters(t *testing.T) {
+	cm := NewConfigManager()
+	
+	// Load multiple valid configurations
+	configs := []configapi.MultiKueueExternalFramework{
+		{Name: "PipelineRun.v1.tekton.dev"},
+		{Name: "Workflow.v1alpha1.argoproj.io"},
+		{Name: "CustomJob.v1alpha1.custom.example.com"},
+	}
+	
+	err := cm.LoadConfigurations(configs)
+	if err != nil {
+		t.Fatalf("Failed to load configurations: %v", err)
+	}
+
+	adapters := cm.GetAllAdapters()
+	if len(adapters) != 3 {
+		t.Errorf("Expected 3 adapters, got %d", len(adapters))
+	}
+
+	// Verify all adapters have valid GVKs
+	for _, adapter := range adapters {
+		gvk := adapter.GVK()
+		if gvk.Group == "" || gvk.Version == "" || gvk.Kind == "" {
+			t.Errorf("Invalid GVK in adapter: %v", gvk)
+		}
+	}
+}

--- a/pkg/controller/jobs/generic/generic_multikueue_adapter.go
+++ b/pkg/controller/jobs/generic/generic_multikueue_adapter.go
@@ -1,0 +1,442 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+// genericAdapter implements the MultiKueueAdapter interface for external frameworks
+// based on configuration.
+type genericAdapter struct {
+	config configapi.ExternalFramework
+	gvk    schema.GroupVersionKind
+}
+
+var _ jobframework.MultiKueueAdapter = (*genericAdapter)(nil)
+
+// NewGenericAdapter creates a new generic adapter for the given external framework configuration.
+func NewGenericAdapter(config configapi.ExternalFramework) jobframework.MultiKueueAdapter {
+	return &genericAdapter{
+		config: config,
+		gvk: schema.GroupVersionKind{
+			Group:   config.Group,
+			Version: config.Version,
+			Kind:    config.Kind,
+		},
+	}
+}
+
+func (a *genericAdapter) SyncJob(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin string) error {
+	// Get the local object
+	localObj := &unstructured.Unstructured{}
+	localObj.SetGroupVersionKind(a.gvk)
+	err := localClient.Get(ctx, key, localObj)
+	if err != nil {
+		return err
+	}
+
+	// Check if remote object already exists
+	remoteObj := &unstructured.Unstructured{}
+	remoteObj.SetGroupVersionKind(a.gvk)
+	err = remoteClient.Get(ctx, key, remoteObj)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	if apierrors.IsNotFound(err) {
+		// Create new remote object
+		return a.createRemoteObject(ctx, remoteClient, localObj, workloadName, origin)
+	}
+
+	// Update existing remote object status
+	return a.syncStatus(ctx, localClient, remoteClient, localObj, remoteObj)
+}
+
+func (a *genericAdapter) createRemoteObject(ctx context.Context, remoteClient client.Client, localObj *unstructured.Unstructured, workloadName, origin string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Create a copy of the local object for the remote cluster
+	remoteObj := localObj.DeepCopy()
+	remoteObj.SetResourceVersion("")
+
+	// Apply creation patches
+	if err := a.applyPatches(remoteObj, a.config.CreationPatches); err != nil {
+		log.Error(err, "Failed to apply creation patches", "gvk", a.gvk, "name", localObj.GetName())
+		return err
+	}
+
+	// Add MultiKueue labels
+	labels := remoteObj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[constants.PrebuiltWorkloadLabel] = workloadName
+	labels[kueue.MultiKueueOriginLabel] = origin
+	remoteObj.SetLabels(labels)
+
+	// Create the object in the remote cluster
+	log.V(2).Info("Creating remote object", "gvk", a.gvk, "name", remoteObj.GetName(), "namespace", remoteObj.GetNamespace())
+	return remoteClient.Create(ctx, remoteObj)
+}
+
+func (a *genericAdapter) syncStatus(ctx context.Context, localClient client.Client, remoteClient client.Client, localObj, remoteObj *unstructured.Unstructured) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Create a deep copy of the original object to calculate the patch against.
+	originalObj := localObj.DeepCopy()
+
+	// Apply sync patches to the local object.
+	if err := a.applySyncPatches(localObj, remoteObj, a.config.SyncPatches); err != nil {
+		log.Error(err, "Failed to apply sync patches", "gvk", a.gvk, "name", localObj.GetName())
+		return err
+	}
+
+	// If there are no changes, do nothing.
+	if equality.Semantic.DeepEqual(localObj, originalObj) {
+		return nil
+	}
+
+	// Create the patch and apply it to the local object's status subresource.
+	patch := client.MergeFrom(originalObj)
+	log.V(2).Info("Syncing status from remote object", "gvk", a.gvk, "name", localObj.GetName())
+	return localClient.Status().Patch(ctx, localObj, patch)
+}
+
+func (a *genericAdapter) applyPatches(obj *unstructured.Unstructured, patches []configapi.JsonPatch) error {
+	if len(patches) == 0 {
+		return nil
+	}
+
+	// Convert object to JSON for patching
+	objBytes, err := json.Marshal(obj.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal object: %w", err)
+	}
+
+	// Apply each patch
+	for _, patch := range patches {
+		objBytes, err = a.applyJsonPatch(objBytes, patch)
+		if err != nil {
+			return fmt.Errorf("failed to apply patch %s %s: %w", patch.Op, patch.Path, err)
+		}
+	}
+
+	// Unmarshal back to object
+	var newObj map[string]interface{}
+	if err := json.Unmarshal(objBytes, &newObj); err != nil {
+		return fmt.Errorf("failed to unmarshal patched object: %w", err)
+	}
+
+	obj.Object = newObj
+	return nil
+}
+
+func (a *genericAdapter) applySyncPatches(localObj, remoteObj *unstructured.Unstructured, patches []configapi.JsonPatch) error {
+	if len(patches) == 0 {
+		// Default behavior: copy entire status
+		if remoteStatus, found, _ := unstructured.NestedMap(remoteObj.Object, "status"); found {
+			unstructured.SetNestedMap(localObj.Object, remoteStatus, "status")
+		}
+		return nil
+	}
+
+	// Convert objects to JSON for patching
+	localBytes, err := json.Marshal(localObj.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal local object: %w", err)
+	}
+
+	remoteBytes, err := json.Marshal(remoteObj.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal remote object: %w", err)
+	}
+
+	// Apply each sync patch
+	for _, patch := range patches {
+		if patch.From != "" {
+			// For patches with "from" field, we need to extract value from remote object
+			value, err := a.extractValueFromRemote(remoteBytes, patch.From)
+			if err != nil {
+				return fmt.Errorf("failed to extract value from remote object at %s: %w", patch.From, err)
+			}
+			patch.Value = value
+		}
+
+		localBytes, err = a.applyJsonPatch(localBytes, patch)
+		if err != nil {
+			return fmt.Errorf("failed to apply sync patch %s %s: %w", patch.Op, patch.Path, err)
+		}
+	}
+
+	// Unmarshal back to object
+	var newObj map[string]interface{}
+	if err := json.Unmarshal(localBytes, &newObj); err != nil {
+		return fmt.Errorf("failed to unmarshal patched local object: %w", err)
+	}
+
+	localObj.Object = newObj
+	return nil
+}
+
+func (a *genericAdapter) applyJsonPatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
+	// This is a simplified implementation. In a real implementation, you would use
+	// a proper JSON patch library like github.com/evanphx/json-patch
+	// For now, we'll implement basic operations
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(objBytes, &obj); err != nil {
+		return nil, err
+	}
+
+	switch patch.Op {
+	case "replace":
+		return a.applyReplacePatch(objBytes, patch)
+	case "add":
+		return a.applyAddPatch(objBytes, patch)
+	case "remove":
+		return a.applyRemovePatch(objBytes, patch)
+	default:
+		return nil, fmt.Errorf("unsupported patch operation: %s", patch.Op)
+	}
+}
+
+func (a *genericAdapter) applyReplacePatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(objBytes, &obj); err != nil {
+		return nil, err
+	}
+
+	// Simple path implementation - assumes simple paths like "/spec/managedBy"
+	path := patch.Path
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+
+	// Split path and navigate to the target location
+	parts := splitJsonPatchPath(path)
+	current := obj
+	for _, part := range parts[:len(parts)-1] {
+		if current[part] == nil {
+			current[part] = make(map[string]interface{})
+		}
+		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
+			current = current[part].(map[string]interface{})
+		} else {
+			return nil, fmt.Errorf("path %s is not a map", path)
+		}
+	}
+
+	// Set the value
+	lastPart := parts[len(parts)-1]
+	current[lastPart] = patch.Value
+
+	return json.Marshal(obj)
+}
+
+func (a *genericAdapter) applyAddPatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
+	// Similar to replace for now
+	return a.applyReplacePatch(objBytes, patch)
+}
+
+func (a *genericAdapter) applyRemovePatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(objBytes, &obj); err != nil {
+		return nil, err
+	}
+
+	path := patch.Path
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+
+	parts := splitJsonPatchPath(path)
+	current := obj
+	for _, part := range parts[:len(parts)-1] {
+		if current[part] == nil {
+			return nil, fmt.Errorf("path %s does not exist", path)
+		}
+		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
+			current = current[part].(map[string]interface{})
+		} else {
+			return nil, fmt.Errorf("path %s is not a map", path)
+		}
+	}
+
+	lastPart := parts[len(parts)-1]
+	delete(current, lastPart)
+
+	return json.Marshal(obj)
+}
+
+func (a *genericAdapter) extractValueFromRemote(remoteBytes []byte, fromPath string) (interface{}, error) {
+	var remoteObj map[string]interface{}
+	if err := json.Unmarshal(remoteBytes, &remoteObj); err != nil {
+		return nil, err
+	}
+
+	path := fromPath
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+
+	parts := splitJsonPatchPath(path)
+	current := remoteObj
+	for _, part := range parts {
+		if current[part] == nil {
+			return nil, fmt.Errorf("path %s does not exist", fromPath)
+		}
+		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
+			current = current[part].(map[string]interface{})
+		} else {
+			return current[part], nil
+		}
+	}
+
+	return current, nil
+}
+
+// splitJsonPatchPath splits a JSON Patch path into parts.
+func splitJsonPatchPath(path string) []string {
+	if len(path) == 0 {
+		return []string{}
+	}
+	// Remove leading slash
+	if path[0] == '/' {
+		path = path[1:]
+	}
+	// Split by slashes for JSON Patch paths like "/spec/managedBy"
+	return strings.Split(path, "/")
+}
+
+// splitJsonPath splits a JSON path into parts
+func splitJsonPath(path string) []string {
+	if len(path) == 0 {
+		return []string{}
+	}
+	// Remove leading dot
+	if path[0] == '.' {
+		path = path[1:]
+	}
+	// Split by dots for JSON paths like "spec.managedBy"
+	return strings.Split(path, ".")
+}
+
+func (a *genericAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(a.gvk)
+	err := remoteClient.Get(ctx, key, obj)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return client.IgnoreNotFound(remoteClient.Delete(ctx, obj, client.PropagationPolicy(metav1.DeletePropagationBackground)))
+}
+
+func (a *genericAdapter) KeepAdmissionCheckPending() bool {
+	return false
+}
+
+func (a *genericAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
+	if !features.Enabled(features.MultiKueueAdaptersForCustomJobs) {
+		return false, "MultiKueueAdaptersForCustomJobs feature gate is disabled", nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(a.gvk)
+	err := c.Get(ctx, key, obj)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Use the configured managedBy path or default to ".spec.managedBy"
+	managedByPath := a.config.ManagedBy
+	if managedByPath == "" {
+		managedByPath = ".spec.managedBy"
+	}
+
+	// Extract the managedBy value using JSONPath
+	managedByValue, err := a.extractManagedByValue(obj, managedByPath)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to extract managedBy value: %w", err)
+	}
+
+	if managedByValue != kueue.MultiKueueControllerName {
+		return false, fmt.Sprintf("Expecting %s to be %q not %q", managedByPath, kueue.MultiKueueControllerName, managedByValue), nil
+	}
+
+	return true, "", nil
+}
+
+func (a *genericAdapter) extractManagedByValue(obj *unstructured.Unstructured, path string) (string, error) {
+	// Simple path extraction without jsonpath library
+	path = strings.TrimPrefix(path, ".")
+	if len(path) == 0 {
+		return "", nil
+	}
+
+	parts := splitJsonPath(path)
+	var current interface{} = obj.Object
+
+	for _, part := range parts {
+		if current == nil {
+			return "", nil
+		}
+		if reflect.TypeOf(current).Kind() == reflect.Map {
+			currentMap := current.(map[string]interface{})
+			if val, exists := currentMap[part]; exists {
+				current = val
+			} else {
+				return "", nil
+			}
+		} else {
+			return "", fmt.Errorf("path %s is not a map", path)
+		}
+	}
+
+	if current == nil {
+		return "", nil
+	}
+
+	if reflect.TypeOf(current).Kind() == reflect.String {
+		return current.(string), nil
+	}
+
+	return "", fmt.Errorf("managedBy value at %s is not a string", path)
+}
+
+func (a *genericAdapter) GVK() schema.GroupVersionKind {
+	return a.gvk
+}

--- a/pkg/controller/jobs/generic/generic_multikueue_adapter.go
+++ b/pkg/controller/jobs/generic/generic_multikueue_adapter.go
@@ -18,9 +18,7 @@ package generic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,7 +30,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -40,23 +37,17 @@ import (
 )
 
 // genericAdapter implements the MultiKueueAdapter interface for external frameworks
-// based on configuration.
+// with hardcoded default behavior as specified in the KEP.
 type genericAdapter struct {
-	config configapi.ExternalFramework
-	gvk    schema.GroupVersionKind
+	gvk schema.GroupVersionKind
 }
 
 var _ jobframework.MultiKueueAdapter = (*genericAdapter)(nil)
 
-// NewGenericAdapter creates a new generic adapter for the given external framework configuration.
-func NewGenericAdapter(config configapi.ExternalFramework) jobframework.MultiKueueAdapter {
+// NewGenericAdapter creates a new generic adapter for the given GVK.
+func NewGenericAdapter(gvk schema.GroupVersionKind) jobframework.MultiKueueAdapter {
 	return &genericAdapter{
-		config: config,
-		gvk: schema.GroupVersionKind{
-			Group:   config.Group,
-			Version: config.Version,
-			Kind:    config.Kind,
-		},
+		gvk: gvk,
 	}
 }
 
@@ -93,11 +84,8 @@ func (a *genericAdapter) createRemoteObject(ctx context.Context, remoteClient cl
 	remoteObj := localObj.DeepCopy()
 	remoteObj.SetResourceVersion("")
 
-	// Apply creation patches
-	if err := a.applyPatches(remoteObj, a.config.CreationPatches); err != nil {
-		log.Error(err, "Failed to apply creation patches", "gvk", a.gvk, "name", localObj.GetName())
-		return err
-	}
+	// Apply default transformation: remove the managedBy field
+	a.removeManagedByField(remoteObj)
 
 	// Add MultiKueue labels
 	labels := remoteObj.GetLabels()
@@ -119,11 +107,8 @@ func (a *genericAdapter) syncStatus(ctx context.Context, localClient client.Clie
 	// Create a deep copy of the original object to calculate the patch against.
 	originalObj := localObj.DeepCopy()
 
-	// Apply sync patches to the local object.
-	if err := a.applySyncPatches(localObj, remoteObj, a.config.SyncPatches); err != nil {
-		log.Error(err, "Failed to apply sync patches", "gvk", a.gvk, "name", localObj.GetName())
-		return err
-	}
+	// Apply default sync: copy entire status from remote to local
+	a.copyStatusFromRemote(localObj, remoteObj)
 
 	// If there are no changes, do nothing.
 	if equality.Semantic.DeepEqual(localObj, originalObj) {
@@ -136,223 +121,26 @@ func (a *genericAdapter) syncStatus(ctx context.Context, localClient client.Clie
 	return localClient.Status().Patch(ctx, localObj, patch)
 }
 
-func (a *genericAdapter) applyPatches(obj *unstructured.Unstructured, patches []configapi.JsonPatch) error {
-	if len(patches) == 0 {
-		return nil
+// removeManagedByField removes the .spec.managedBy field from the object
+func (a *genericAdapter) removeManagedByField(obj *unstructured.Unstructured) {
+	spec, exists, err := unstructured.NestedMap(obj.Object, "spec")
+	if !exists || err != nil {
+		return
 	}
 
-	// Convert object to JSON for patching
-	objBytes, err := json.Marshal(obj.Object)
-	if err != nil {
-		return fmt.Errorf("failed to marshal object: %w", err)
-	}
-
-	// Apply each patch
-	for _, patch := range patches {
-		objBytes, err = a.applyJsonPatch(objBytes, patch)
-		if err != nil {
-			return fmt.Errorf("failed to apply patch %s %s: %w", patch.Op, patch.Path, err)
-		}
-	}
-
-	// Unmarshal back to object
-	var newObj map[string]interface{}
-	if err := json.Unmarshal(objBytes, &newObj); err != nil {
-		return fmt.Errorf("failed to unmarshal patched object: %w", err)
-	}
-
-	obj.Object = newObj
-	return nil
+	delete(spec, "managedBy")
+	obj.Object["spec"] = spec
 }
 
-func (a *genericAdapter) applySyncPatches(localObj, remoteObj *unstructured.Unstructured, patches []configapi.JsonPatch) error {
-	if len(patches) == 0 {
-		// Default behavior: copy entire status
-		if remoteStatus, found, _ := unstructured.NestedMap(remoteObj.Object, "status"); found {
-			unstructured.SetNestedMap(localObj.Object, remoteStatus, "status")
-		}
-		return nil
+// copyStatusFromRemote copies the entire status from remote object to local object
+func (a *genericAdapter) copyStatusFromRemote(localObj, remoteObj *unstructured.Unstructured) {
+	remoteStatus, exists, err := unstructured.NestedMap(remoteObj.Object, "status")
+	if !exists || err != nil {
+		return
 	}
 
-	// Convert objects to JSON for patching
-	localBytes, err := json.Marshal(localObj.Object)
-	if err != nil {
-		return fmt.Errorf("failed to marshal local object: %w", err)
-	}
-
-	remoteBytes, err := json.Marshal(remoteObj.Object)
-	if err != nil {
-		return fmt.Errorf("failed to marshal remote object: %w", err)
-	}
-
-	// Apply each sync patch
-	for _, patch := range patches {
-		if patch.From != "" {
-			// For patches with "from" field, we need to extract value from remote object
-			value, err := a.extractValueFromRemote(remoteBytes, patch.From)
-			if err != nil {
-				return fmt.Errorf("failed to extract value from remote object at %s: %w", patch.From, err)
-			}
-			patch.Value = value
-		}
-
-		localBytes, err = a.applyJsonPatch(localBytes, patch)
-		if err != nil {
-			return fmt.Errorf("failed to apply sync patch %s %s: %w", patch.Op, patch.Path, err)
-		}
-	}
-
-	// Unmarshal back to object
-	var newObj map[string]interface{}
-	if err := json.Unmarshal(localBytes, &newObj); err != nil {
-		return fmt.Errorf("failed to unmarshal patched local object: %w", err)
-	}
-
-	localObj.Object = newObj
-	return nil
-}
-
-func (a *genericAdapter) applyJsonPatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
-	// This is a simplified implementation. In a real implementation, you would use
-	// a proper JSON patch library like github.com/evanphx/json-patch
-	// For now, we'll implement basic operations
-
-	var obj map[string]interface{}
-	if err := json.Unmarshal(objBytes, &obj); err != nil {
-		return nil, err
-	}
-
-	switch patch.Op {
-	case "replace":
-		return a.applyReplacePatch(objBytes, patch)
-	case "add":
-		return a.applyAddPatch(objBytes, patch)
-	case "remove":
-		return a.applyRemovePatch(objBytes, patch)
-	default:
-		return nil, fmt.Errorf("unsupported patch operation: %s", patch.Op)
-	}
-}
-
-func (a *genericAdapter) applyReplacePatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
-	var obj map[string]interface{}
-	if err := json.Unmarshal(objBytes, &obj); err != nil {
-		return nil, err
-	}
-
-	// Simple path implementation - assumes simple paths like "/spec/managedBy"
-	path := patch.Path
-	if len(path) > 0 && path[0] == '/' {
-		path = path[1:]
-	}
-
-	// Split path and navigate to the target location
-	parts := splitJsonPatchPath(path)
-	current := obj
-	for _, part := range parts[:len(parts)-1] {
-		if current[part] == nil {
-			current[part] = make(map[string]interface{})
-		}
-		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
-			current = current[part].(map[string]interface{})
-		} else {
-			return nil, fmt.Errorf("path %s is not a map", path)
-		}
-	}
-
-	// Set the value
-	lastPart := parts[len(parts)-1]
-	current[lastPart] = patch.Value
-
-	return json.Marshal(obj)
-}
-
-func (a *genericAdapter) applyAddPatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
-	// Similar to replace for now
-	return a.applyReplacePatch(objBytes, patch)
-}
-
-func (a *genericAdapter) applyRemovePatch(objBytes []byte, patch configapi.JsonPatch) ([]byte, error) {
-	var obj map[string]interface{}
-	if err := json.Unmarshal(objBytes, &obj); err != nil {
-		return nil, err
-	}
-
-	path := patch.Path
-	if len(path) > 0 && path[0] == '/' {
-		path = path[1:]
-	}
-
-	parts := splitJsonPatchPath(path)
-	current := obj
-	for _, part := range parts[:len(parts)-1] {
-		if current[part] == nil {
-			return nil, fmt.Errorf("path %s does not exist", path)
-		}
-		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
-			current = current[part].(map[string]interface{})
-		} else {
-			return nil, fmt.Errorf("path %s is not a map", path)
-		}
-	}
-
-	lastPart := parts[len(parts)-1]
-	delete(current, lastPart)
-
-	return json.Marshal(obj)
-}
-
-func (a *genericAdapter) extractValueFromRemote(remoteBytes []byte, fromPath string) (interface{}, error) {
-	var remoteObj map[string]interface{}
-	if err := json.Unmarshal(remoteBytes, &remoteObj); err != nil {
-		return nil, err
-	}
-
-	path := fromPath
-	if len(path) > 0 && path[0] == '/' {
-		path = path[1:]
-	}
-
-	parts := splitJsonPatchPath(path)
-	current := remoteObj
-	for _, part := range parts {
-		if current[part] == nil {
-			return nil, fmt.Errorf("path %s does not exist", fromPath)
-		}
-		if reflect.TypeOf(current[part]).Kind() == reflect.Map {
-			current = current[part].(map[string]interface{})
-		} else {
-			return current[part], nil
-		}
-	}
-
-	return current, nil
-}
-
-// splitJsonPatchPath splits a JSON Patch path into parts.
-func splitJsonPatchPath(path string) []string {
-	if len(path) == 0 {
-		return []string{}
-	}
-	// Remove leading slash
-	if path[0] == '/' {
-		path = path[1:]
-	}
-	// Split by slashes for JSON Patch paths like "/spec/managedBy"
-	return strings.Split(path, "/")
-}
-
-// splitJsonPath splits a JSON path into parts
-func splitJsonPath(path string) []string {
-	if len(path) == 0 {
-		return []string{}
-	}
-	// Remove leading dot
-	if path[0] == '.' {
-		path = path[1:]
-	}
-	// Split by dots for JSON paths like "spec.managedBy"
-	return strings.Split(path, ".")
+	// Set the status in the local object
+	localObj.Object["status"] = remoteStatus
 }
 
 func (a *genericAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
@@ -381,60 +169,70 @@ func (a *genericAdapter) IsJobManagedByKueue(ctx context.Context, c client.Clien
 		return false, "", err
 	}
 
-	// Use the configured managedBy path or default to ".spec.managedBy"
-	managedByPath := a.config.ManagedBy
-	if managedByPath == "" {
-		managedByPath = ".spec.managedBy"
-	}
-
-	// Extract the managedBy value using JSONPath
-	managedByValue, err := a.extractManagedByValue(obj, managedByPath)
+	// Use the default managedBy path: .spec.managedBy
+	managedByValue, err := a.extractManagedByValue(obj, ".spec.managedBy")
 	if err != nil {
 		return false, "", fmt.Errorf("failed to extract managedBy value: %w", err)
 	}
 
 	if managedByValue != kueue.MultiKueueControllerName {
-		return false, fmt.Sprintf("Expecting %s to be %q not %q", managedByPath, kueue.MultiKueueControllerName, managedByValue), nil
+		return false, fmt.Sprintf("Expecting .spec.managedBy to be %q not %q", kueue.MultiKueueControllerName, managedByValue), nil
 	}
 
 	return true, "", nil
 }
 
 func (a *genericAdapter) extractManagedByValue(obj *unstructured.Unstructured, path string) (string, error) {
-	// Simple path extraction without jsonpath library
-	path = strings.TrimPrefix(path, ".")
-	if len(path) == 0 {
-		return "", nil
+	// Split the path into parts (e.g., ".spec.managedBy" -> ["spec", "managedBy"])
+	parts := a.splitJsonPath(path)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("invalid path: %s", path)
 	}
 
-	parts := splitJsonPath(path)
-	var current interface{} = obj.Object
-
-	for _, part := range parts {
-		if current == nil {
+	// Navigate to the target field
+	current := obj.Object
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			// Last part, extract the value
+			if value, exists := current[part]; exists {
+				if strValue, ok := value.(string); ok {
+					return strValue, nil
+				}
+				// Return empty string for non-string values (consistent with missing field)
+				return "", nil
+			}
+			// Return empty string when field is not found (no error)
 			return "", nil
 		}
-		if reflect.TypeOf(current).Kind() == reflect.Map {
-			currentMap := current.(map[string]interface{})
-			if val, exists := currentMap[part]; exists {
-				current = val
+
+		// Navigate deeper
+		if next, exists := current[part]; exists {
+			if mapValue, ok := next.(map[string]interface{}); ok {
+				current = mapValue
 			} else {
+				// Return empty string for invalid path structure (consistent with missing field)
 				return "", nil
 			}
 		} else {
-			return "", fmt.Errorf("path %s is not a map", path)
+			// Return empty string when intermediate path component is not found
+			return "", nil
 		}
 	}
 
-	if current == nil {
-		return "", nil
-	}
+	return "", fmt.Errorf("unexpected path traversal end")
+}
 
-	if reflect.TypeOf(current).Kind() == reflect.String {
-		return current.(string), nil
+// splitJsonPath splits a JSON path into parts
+func (a *genericAdapter) splitJsonPath(path string) []string {
+	if len(path) == 0 {
+		return []string{}
 	}
-
-	return "", fmt.Errorf("managedBy value at %s is not a string", path)
+	// Remove leading dot
+	if path[0] == '.' {
+		path = path[1:]
+	}
+	// Split by dots for JSON paths like "spec.managedBy"
+	return strings.Split(path, ".")
 }
 
 func (a *genericAdapter) GVK() schema.GroupVersionKind {

--- a/pkg/controller/jobs/generic/generic_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/generic/generic_multikueue_adapter_test.go
@@ -1,0 +1,382 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+func TestGenericAdapter_IsJobManagedByKueue(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         configapi.ExternalFramework
+		object         *unstructured.Unstructured
+		featureEnabled bool
+		want           bool
+		wantReason     string
+		wantErr        bool
+	}{
+		{
+			name: "feature gate disabled",
+			config: configapi.ExternalFramework{
+				Group:   "test.example.com",
+				Version: "v1",
+				Kind:    "TestJob",
+			},
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"managedBy": kueue.MultiKueueControllerName,
+					},
+				},
+			},
+			featureEnabled: false,
+			want:           false,
+			wantReason:     "MultiKueueAdaptersForCustomJobs feature gate is disabled",
+			wantErr:        false,
+		},
+		{
+			name: "managed by kueue with default path",
+			config: configapi.ExternalFramework{
+				Group:   "test.example.com",
+				Version: "v1",
+				Kind:    "TestJob",
+			},
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"managedBy": kueue.MultiKueueControllerName,
+					},
+				},
+			},
+			featureEnabled: true,
+			want:           true,
+			wantReason:     "",
+			wantErr:        false,
+		},
+		{
+			name: "managed by kueue with custom path",
+			config: configapi.ExternalFramework{
+				Group:     "test.example.com",
+				Version:   "v1",
+				Kind:      "TestJob",
+				ManagedBy: ".metadata.labels.managedBy",
+			},
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"managedBy": kueue.MultiKueueControllerName,
+						},
+					},
+				},
+			},
+			featureEnabled: true,
+			want:           true,
+			wantReason:     "",
+			wantErr:        false,
+		},
+		{
+			name: "not managed by kueue",
+			config: configapi.ExternalFramework{
+				Group:   "test.example.com",
+				Version: "v1",
+				Kind:    "TestJob",
+			},
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"managedBy": "other-controller",
+					},
+				},
+			},
+			featureEnabled: true,
+			want:           false,
+			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"other-controller\"",
+			wantErr:        false,
+		},
+		{
+			name: "managedBy field not found",
+			config: configapi.ExternalFramework{
+				Group:   "test.example.com",
+				Version: "v1",
+				Kind:    "TestJob",
+			},
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"otherField": "value",
+					},
+				},
+			},
+			featureEnabled: true,
+			want:           false,
+			wantReason:     "Expecting .spec.managedBy to be \"kueue.x-k8s.io/multikueue\" not \"\"",
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set feature gate
+			originalValue := features.Enabled(features.MultiKueueAdaptersForCustomJobs)
+			features.SetEnable(features.MultiKueueAdaptersForCustomJobs, tt.featureEnabled)
+			defer features.SetEnable(features.MultiKueueAdaptersForCustomJobs, originalValue)
+
+			adapter := NewGenericAdapter(tt.config)
+			client := fake.NewClientBuilder().Build()
+
+			// Create the object in the fake client
+			tt.object.SetName("test-job")
+			tt.object.SetNamespace("default")
+			tt.object.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   tt.config.Group,
+				Version: tt.config.Version,
+				Kind:    tt.config.Kind,
+			})
+			// Set the APIVersion for the unstructured object
+			tt.object.SetAPIVersion(tt.config.Group + "/" + tt.config.Version)
+			if err := client.Create(context.Background(), tt.object); err != nil {
+				t.Fatalf("Failed to create test object: %v", err)
+			}
+
+			got, gotReason, err := adapter.IsJobManagedByKueue(context.Background(), client, types.NamespacedName{
+				Name:      "test-job",
+				Namespace: "default",
+			})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsJobManagedByKueue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsJobManagedByKueue() got = %v, want %v", got, tt.want)
+			}
+			if gotReason != tt.wantReason {
+				t.Errorf("IsJobManagedByKueue() gotReason = %v, want %v", gotReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+func TestGenericAdapter_GVK(t *testing.T) {
+	config := configapi.ExternalFramework{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+
+	adapter := NewGenericAdapter(config)
+	gvk := adapter.GVK()
+
+	expectedGVK := schema.GroupVersionKind{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+
+	if gvk != expectedGVK {
+		t.Errorf("GVK() = %v, want %v", gvk, expectedGVK)
+	}
+}
+
+func TestGenericAdapter_KeepAdmissionCheckPending(t *testing.T) {
+	config := configapi.ExternalFramework{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+
+	adapter := NewGenericAdapter(config)
+	result := adapter.KeepAdmissionCheckPending()
+
+	if result != false {
+		t.Errorf("KeepAdmissionCheckPending() = %v, want false", result)
+	}
+}
+
+func TestConfigManager_LoadConfigurations(t *testing.T) {
+	tests := []struct {
+		name    string
+		configs []configapi.ExternalFramework
+		wantErr bool
+	}{
+		{
+			name: "valid configuration",
+			configs: []configapi.ExternalFramework{
+				{
+					Group:   "test.example.com",
+					Version: "v1",
+					Kind:    "TestJob",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid configuration - missing group",
+			configs: []configapi.ExternalFramework{
+				{
+					Version: "v1",
+					Kind:    "TestJob",
+				},
+			},
+			wantErr: false, // Should log error but continue
+		},
+		{
+			name: "invalid configuration - missing version",
+			configs: []configapi.ExternalFramework{
+				{
+					Group: "test.example.com",
+					Kind:  "TestJob",
+				},
+			},
+			wantErr: false, // Should log error but continue
+		},
+		{
+			name: "invalid configuration - missing kind",
+			configs: []configapi.ExternalFramework{
+				{
+					Group:   "test.example.com",
+					Version: "v1",
+				},
+			},
+			wantErr: false, // Should log error but continue
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := NewConfigManager()
+			err := cm.LoadConfigurations(tt.configs)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadConfigurations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConfigManager_GetAdapter(t *testing.T) {
+	cm := NewConfigManager()
+	configs := []configapi.ExternalFramework{
+		{
+			Group:   "test.example.com",
+			Version: "v1",
+			Kind:    "TestJob",
+		},
+	}
+
+	err := cm.LoadConfigurations(configs)
+	if err != nil {
+		t.Fatalf("Failed to load configurations: %v", err)
+	}
+
+	// Test getting existing adapter
+	gvk := schema.GroupVersionKind{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+	adapter := cm.GetAdapter(gvk)
+	if adapter == nil {
+		t.Error("GetAdapter() returned nil for existing GVK")
+	}
+
+	// Test getting non-existing adapter
+	nonExistingGVK := schema.GroupVersionKind{
+		Group:   "other.example.com",
+		Version: "v1",
+		Kind:    "OtherJob",
+	}
+	adapter = cm.GetAdapter(nonExistingGVK)
+	if adapter != nil {
+		t.Error("GetAdapter() returned non-nil for non-existing GVK")
+	}
+}
+
+func TestConfigManager_ApplyDefaults(t *testing.T) {
+	cm := NewConfigManager()
+
+	// Test minimal configuration
+	config := configapi.ExternalFramework{
+		Group:   "test.example.com",
+		Version: "v1",
+		Kind:    "TestJob",
+	}
+
+	configWithDefaults := cm.applyDefaults(config)
+
+	// Check that defaults were applied
+	if configWithDefaults.ManagedBy != ".spec.managedBy" {
+		t.Errorf("Expected default managedBy path, got %s", configWithDefaults.ManagedBy)
+	}
+
+	if len(configWithDefaults.CreationPatches) != 1 {
+		t.Errorf("Expected 1 default creation patch, got %d", len(configWithDefaults.CreationPatches))
+	}
+
+	if len(configWithDefaults.SyncPatches) != 1 {
+		t.Errorf("Expected 1 default sync patch, got %d", len(configWithDefaults.SyncPatches))
+	}
+
+	// Test configuration with custom values
+	customConfig := configapi.ExternalFramework{
+		Group:     "test.example.com",
+		Version:   "v1",
+		Kind:      "TestJob",
+		ManagedBy: ".metadata.labels.managedBy",
+		CreationPatches: []configapi.JsonPatch{
+			{
+				Op:    "replace",
+				Path:  "/spec/customField",
+				Value: "customValue",
+			},
+		},
+		SyncPatches: []configapi.JsonPatch{
+			{
+				Op:   "replace",
+				Path: "/status/customStatus",
+				From: "/status/customStatus",
+			},
+		},
+	}
+
+	customConfigWithDefaults := cm.applyDefaults(customConfig)
+
+	// Check that custom values were preserved
+	if customConfigWithDefaults.ManagedBy != ".metadata.labels.managedBy" {
+		t.Errorf("Expected custom managedBy path, got %s", customConfigWithDefaults.ManagedBy)
+	}
+
+	if len(customConfigWithDefaults.CreationPatches) != 1 {
+		t.Errorf("Expected 1 custom creation patch, got %d", len(customConfigWithDefaults.CreationPatches))
+	}
+
+	if len(customConfigWithDefaults.SyncPatches) != 1 {
+		t.Errorf("Expected 1 custom sync patch, got %d", len(customConfigWithDefaults.SyncPatches))
+	}
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -187,6 +187,12 @@ const (
 	// In flavor fungibility, the preference whether to preempt or borrow is inferred from flavor fungibility policy
 	// This feature gate is going to be replaced by an API before graduation or deprecation.
 	FlavorFungibilityImplicitPreferenceDefault featuregate.Feature = "FlavorFungibilityImplicitPreferenceDefault"
+
+	// owner: @khrm
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2349-multikueue-external-custom-job-support
+	//
+	// Enable MultiKueue support for external custom Jobs via configurable adapters.
+	MultiKueueAdaptersForCustomJobs featuregate.Feature = "MultiKueueAdaptersForCustomJobs"
 )
 
 func init() {
@@ -289,6 +295,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FlavorFungibilityImplicitPreferenceDefault: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	MultiKueueAdaptersForCustomJobs: {
+		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/site/static/examples/multikueue/external-frameworks-config.yaml
+++ b/site/static/examples/multikueue/external-frameworks-config.yaml
@@ -1,0 +1,73 @@
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    gcInterval: 1m
+    origin: "multikueue-manager"
+    workerLostTimeout: 15m
+    externalFrameworks:
+      # Example 1: Tekton PipelineRun with minimal configuration
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+      
+      # Example 2: Tekton PipelineRun with custom configuration
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+        managedBy: ".spec.managedBy"
+        creationPatches:
+          - op: replace
+            path: /spec/managedBy
+            value: null
+          - op: replace
+            path: /spec/pipelineRef
+            value:
+              name: "remote-pipeline"
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+      
+      # Example 3: Custom Job with different managedBy path
+      - group: "custom.example.com"
+        version: "v1alpha1"
+        kind: "CustomJob"
+        managedBy: ".metadata.labels.managedBy"
+        creationPatches:
+          - op: replace
+            path: /metadata/labels/managedBy
+            value: null
+          - op: add
+            path: /spec/clusterName
+            value: "worker-cluster"
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+          - op: replace
+            path: /status/conditions
+            from: /status/conditions
+      
+      # Example 4: Argo Workflow example
+      - group: "argoproj.io"
+        version: "v1alpha1"
+        kind: "Workflow"
+        managedBy: ".spec.managedBy"
+        creationPatches:
+          - op: replace
+            path: /spec/managedBy
+            value: null
+          - op: replace
+            path: /spec/entrypoint
+            value: "remote-entrypoint"
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+          - op: replace
+            path: /status/nodes
+            from: /status/nodes

--- a/site/static/examples/multikueue/external-frameworks-config.yaml
+++ b/site/static/examples/multikueue/external-frameworks-config.yaml
@@ -9,65 +9,11 @@ data:
     origin: "multikueue-manager"
     workerLostTimeout: 15m
     externalFrameworks:
-      # Example 1: Tekton PipelineRun with minimal configuration
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
+      # Example 1: Tekton PipelineRun
+      - name: "PipelineRun.v1.tekton.dev"
       
-      # Example 2: Tekton PipelineRun with custom configuration
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
-        managedBy: ".spec.managedBy"
-        creationPatches:
-          - op: replace
-            path: /spec/managedBy
-            value: null
-          - op: replace
-            path: /spec/pipelineRef
-            value:
-              name: "remote-pipeline"
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
+      # Example 2: Custom Job
+      - name: "CustomJob.v1alpha1.custom.example.com"
       
-      # Example 3: Custom Job with different managedBy path
-      - group: "custom.example.com"
-        version: "v1alpha1"
-        kind: "CustomJob"
-        managedBy: ".metadata.labels.managedBy"
-        creationPatches:
-          - op: replace
-            path: /metadata/labels/managedBy
-            value: null
-          - op: add
-            path: /spec/clusterName
-            value: "worker-cluster"
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
-          - op: replace
-            path: /status/conditions
-            from: /status/conditions
-      
-      # Example 4: Argo Workflow example
-      - group: "argoproj.io"
-        version: "v1alpha1"
-        kind: "Workflow"
-        managedBy: ".spec.managedBy"
-        creationPatches:
-          - op: replace
-            path: /spec/managedBy
-            value: null
-          - op: replace
-            path: /spec/entrypoint
-            value: "remote-entrypoint"
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
-          - op: replace
-            path: /status/nodes
-            from: /status/nodes
+      # Example 3: Argo Workflow
+      - name: "Workflow.v1alpha1.argoproj.io"

--- a/site/static/examples/multikueue/tekton-pipelinerun-example.yaml
+++ b/site/static/examples/multikueue/tekton-pipelinerun-example.yaml
@@ -14,18 +14,7 @@ data:
     origin: "multikueue-manager"
     workerLostTimeout: 15m
     externalFrameworks:
-      - group: "tekton.dev"
-        version: "v1"
-        kind: "PipelineRun"
-        managedBy: ".spec.managedBy"
-        creationPatches:
-          - op: replace
-            path: /spec/managedBy
-            value: null
-        syncPatches:
-          - op: replace
-            path: /status
-            from: /status
+      - name: "PipelineRun.v1.tekton.dev"
 
 ---
 # 2. Resource Flavor for the worker cluster

--- a/site/static/examples/multikueue/tekton-pipelinerun-example.yaml
+++ b/site/static/examples/multikueue/tekton-pipelinerun-example.yaml
@@ -1,0 +1,125 @@
+# Example: MultiKueue with Tekton PipelineRun
+# This example shows how to configure MultiKueue to work with Tekton PipelineRun
+
+---
+# 1. Kueue Configuration with external frameworks enabled
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+metadata:
+  name: kueue-manager-config
+  namespace: kueue-system
+data:
+  multikueue:
+    gcInterval: 1m
+    origin: "multikueue-manager"
+    workerLostTimeout: 15m
+    externalFrameworks:
+      - group: "tekton.dev"
+        version: "v1"
+        kind: "PipelineRun"
+        managedBy: ".spec.managedBy"
+        creationPatches:
+          - op: replace
+            path: /spec/managedBy
+            value: null
+        syncPatches:
+          - op: replace
+            path: /status
+            from: /status
+
+---
+# 2. Resource Flavor for the worker cluster
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "worker-cluster"
+spec:
+  nodeLabels:
+    - key: "kubernetes.io/hostname"
+      operator: Exists
+
+---
+# 3. Cluster Queue that can use the worker cluster
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "tekton-queue"
+spec:
+  namespaceSelector: {} # match all namespaces
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: "worker-cluster"
+      resources:
+      - name: "cpu"
+        nominalQuota: 10
+      - name: "memory"
+        nominalQuota: 20Gi
+  admissionChecks:
+  - "multikueue-tekton"
+
+---
+# 4. Local Queue for the user
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "default"
+  name: "user-queue"
+spec:
+  clusterQueue: "tekton-queue"
+
+---
+# 5. MultiKueue Admission Check
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata:
+  name: multikueue-tekton
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: multikueue-tekton-config
+
+---
+# 6. MultiKueue Configuration
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueConfig
+metadata:
+  name: multikueue-tekton-config
+spec:
+  clusters:
+  - worker-cluster-1
+
+---
+# 7. MultiKueue Cluster (worker cluster)
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata:
+  name: worker-cluster-1
+spec:
+  kubeConfig:
+    locationType: Secret
+    location: worker-cluster-1-secret
+    # Note: You need to create a secret named "worker-cluster-1-secret" 
+    # in the kueue-system namespace with the kubeconfig for the worker cluster
+
+---
+# 8. Example Tekton PipelineRun that will be managed by MultiKueue
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: example-pipeline
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  managedBy: "kueue.x-k8s.io/multikueue"  # This tells Kueue to manage this PipelineRun
+  pipelineRef:
+    name: example-pipeline
+  params:
+  - name: message
+    value: "Hello from MultiKueue!"
+  workspaces:
+  - name: shared-workspace
+    emptyDir: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - MultiKueue now supports external frameworks via generic adapters.
  - Configure external integrations using multikueue.externalFrameworks (GVK format, e.g., PipelineRun.v1.tekton.dev).
  - Introduces the MultiKueueAdaptersForCustomJobs feature gate to enable this capability.

- Documentation
  - New guide for configuring external frameworks, including enabling the feature gate.
  - Added example configurations and end-to-end samples (e.g., Tekton PipelineRun, Argo Workflow, custom jobs).

- Tests
  - Added unit tests covering generic adapter behavior and external framework configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->