### PR TITLE
refactor(multikueue): Relocate and centralize external frameworks ada…

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -291,7 +291,7 @@ type MultiKueue struct {
 type MultiKueueExternalFramework struct {
 	// Name is the GVK of the resource that are
 	// managed by external controllers
-	// the expected format is `Kind.version.group.com`.
+	// the expected format is `kind.version.group`.
 	Name string `json:"name"`
 }
 

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/config_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/config_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package generic
+package externalframeworks
 
 import (
 	"testing"
@@ -24,9 +24,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 )
 
-func TestConfigManager_LoadConfigurations(t *testing.T) {
-	cm := NewConfigManager()
-
+func TestInitialize(t *testing.T) {
 	tests := []struct {
 		name    string
 		configs []configapi.MultiKueueExternalFramework
@@ -75,56 +73,15 @@ func TestConfigManager_LoadConfigurations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := cm.LoadConfigurations(tt.configs)
+			err := Initialize(tt.configs)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ConfigManager.LoadConfigurations() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Initialize() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestConfigManager_GetAdapter(t *testing.T) {
-	cm := NewConfigManager()
-
-	// Load a valid configuration
-	configs := []configapi.MultiKueueExternalFramework{
-		{Name: "PipelineRun.v1.tekton.dev"},
-	}
-	if err := cm.LoadConfigurations(configs); err != nil {
-		t.Fatalf("Failed to load configurations: %v", err)
-	}
-
-	// Test getting adapter for configured GVK
-	gvk := schema.GroupVersionKind{
-		Group:   "tekton.dev",
-		Version: "v1",
-		Kind:    "PipelineRun",
-	}
-
-	adapter := cm.GetAdapter(gvk)
-	if adapter == nil {
-		t.Error("Expected adapter to be returned for configured GVK")
-	}
-	if adapter.GVK() != gvk {
-		t.Errorf("Expected GVK %v, got %v", gvk, adapter.GVK())
-	}
-
-	// Test getting adapter for unconfigured GVK
-	unconfiguredGVK := schema.GroupVersionKind{
-		Group:   "example.com",
-		Version: "v1",
-		Kind:    "Example",
-	}
-
-	unconfiguredAdapter := cm.GetAdapter(unconfiguredGVK)
-	if unconfiguredAdapter != nil {
-		t.Error("Expected nil adapter for unconfigured GVK")
-	}
-}
-
-func TestConfigManager_GetAllAdapters(t *testing.T) {
-	cm := NewConfigManager()
-
+func TestGetAllAdapters(t *testing.T) {
 	// Load multiple valid configurations
 	configs := []configapi.MultiKueueExternalFramework{
 		{Name: "PipelineRun.v1.tekton.dev"},
@@ -132,11 +89,11 @@ func TestConfigManager_GetAllAdapters(t *testing.T) {
 		{Name: "CustomJob.v1alpha1.custom.example.com"},
 	}
 
-	if err := cm.LoadConfigurations(configs); err != nil {
+	if err := Initialize(configs); err != nil {
 		t.Fatalf("Failed to load configurations: %v", err)
 	}
 
-	adapters := cm.GetAllAdapters()
+	adapters := GetAllAdapters()
 	if len(adapters) != 3 {
 		t.Errorf("Expected 3 adapters, got %d", len(adapters))
 	}

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -802,7 +802,7 @@ GroupVersionKind (GVK) for MultiKueue operations.</p>
 <td>
    <p>Name is the GVK of the resource that are
 managed by external controllers
-the expected format is <code>Kind.version.group.com</code>.</p>
+the expected format is <code>kind.version.group</code>.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
…pter logic

This commit refactors the MultiKueue external frameworks adapter to improve code organization and centralize configuration validation.

Key changes include:
- Moves the adapter logic from `pkg/controller/jobs/generic` to `pkg/controller/admissionchecks/multikueue/externalframeworks` to better reflect its purpose.
- Renames `genericAdapter` to `Adapter`.
- Centralizes all validation for the `externalFrameworks` configuration into `pkg/config/validation.go`, including checks for feature gate enablement, duplicate GVKs, and conflicts with built-in adapters.
- Simplifies the adapter initialization by removing the `ConfigManager` in favor of package-level functions.
- Improves unit tests by using `cmp.Diff` for robust error comparison and removes a redundant integration test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified external-framework adapter initialization at startup with adapters exposed via a global registry.

- **Bug Fixes**
  - Validation now detects duplicate external frameworks and flags conflicts with built-in adapters to prevent misconfiguration.
  - Configuration errors during external-framework initialization surfaced more clearly.

- **Documentation**
  - Clarified external framework name format to kind.version.group (lowercased Kind).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->