### PR TITLE
KEP-2349: Move MultiKueue external custom Job support to Beta

### DIFF
--- a/keps/2349-multikueue-external-custom-job-support/README.md
+++ b/keps/2349-multikueue-external-custom-job-support/README.md
@@ -158,7 +158,6 @@ Cover the critical part of newly created code.
 - **Feature Gate:** `MultiKueueAdaptersForCustomJobs`
 - Implementation is behind a feature gate.
 - The generic adapter for custom jobs is implemented.
-- *Completed*
 
 #### Beta
 - **Milestone:** v0.15

--- a/keps/2349-multikueue-external-custom-job-support/README.md
+++ b/keps/2349-multikueue-external-custom-job-support/README.md
@@ -158,6 +158,7 @@ Cover the critical part of newly created code.
 - **Feature Gate:** `MultiKueueAdaptersForCustomJobs`
 - Implementation is behind a feature gate.
 - The generic adapter for custom jobs is implemented.
+- *Completed*
 
 #### Beta
 - **Milestone:** v0.15
@@ -177,6 +178,7 @@ Cover the critical part of newly created code.
 
 * 2024-06-20 First draft
 * 2025-07-15 Second draft
+* 2025-11-11 Beta graduation
 
 
 ## Drawbacks

--- a/keps/2349-multikueue-external-custom-job-support/kep.yaml
+++ b/keps/2349-multikueue-external-custom-job-support/kep.yaml
@@ -16,15 +16,16 @@ see-also:
   - "/keps/693-multikueue"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.14"
+latest-milestone: "v0.15"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.14"
+  beta: "v0.15"
 feature-gates:
   - MultiKueueAdaptersForCustomJobs

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -303,6 +303,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	MultiKueueAdaptersForCustomJobs: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
 	WorkloadRequestUseMergePatch: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -42,7 +42,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	dispatcher "sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -146,7 +145,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		})
 
 		ginkgo.BeforeEach(func() {
-			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueAdaptersForCustomJobs, true)
 			managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
 			worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
 			worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)


### PR DESCRIPTION
Added MultiKueue external custom Job support to Beta. Modified integration to remove feature gate.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MultiKueueAdaptersForCustomJobs graduates from Alpha to Beta and is enabled by default in v0.15.

* **Documentation**
  * Implementation history and milestone info updated to record the v0.15 Beta graduation.

* **Tests**
  * Integration tests adjusted to reflect the feature's Beta/default status (removed explicit feature-gate setup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->